### PR TITLE
feat: Resource analytics (ClickHouse) — dashboard overview, per-article/gist, custom ranges

### DIFF
--- a/docs/resource-analytics-plan.md
+++ b/docs/resource-analytics-plan.md
@@ -35,18 +35,24 @@ Single events table keyed by resource, not by article only.
 
 ```sql
 CREATE TABLE resource_views (
-  resource_type  LowCardinality(String), -- e.g. ARTICLE, GIST (allowlist)
-  resource_id    UUID,
-  viewer_id      Nullable(UUID),         -- NULL when anonymous
-  session_id     String,                 -- stable anonymous bucket (cookie / hash)
-  referrer       Nullable(String),
-  country_code   Nullable(String),       -- optional, from geo later
-  viewed_at      DateTime DEFAULT now()
+  resource_type   LowCardinality(String), -- e.g. ARTICLE, GIST (allowlist)
+  resource_id     UUID,
+  session_type    LowCardinality(String), -- ANON | AUTHENTICATED
+  session_id      String,                 -- ANON: client token; AUTHENTICATED: user id (UUID string)
+  referrer        Nullable(String),
+  country_code    Nullable(String),
+  viewed_at       DateTime DEFAULT now()
 )
 ENGINE = MergeTree()
 PARTITION BY toYYYYMM(viewed_at)
 ORDER BY (resource_type, resource_id, viewed_at);
 ```
+
+Existing tables with `viewer_id`: run these **one statement per HTTP request** (or `clickhouse-client`), in order:
+
+1. `migrations/clickhouse-migrate-session-type-1-add-column.sql`
+2. `migrations/clickhouse-migrate-session-type-2-backfill.sql`
+3. `migrations/clickhouse-migrate-session-type-3-drop-viewer.sql`
 
 **Deduped “views” metric (v1):** `uniq(session_id)` per calendar day per resource, for a chosen window:
 
@@ -68,10 +74,10 @@ Adjust interval via app-level parameter (7 / 30 / 90 / custom).
 
 Append-on-each-load stores **one row per event**. That supports **two KPIs from the same table** without changing ingestion:
 
-| Metric | Meaning | Per-day aggregation |
-|--------|---------|---------------------|
-| **Impressions** | Total times the page was loaded and sent an event (includes refreshes, repeat loads same session). | `count()` |
-| **Unique viewers** | Distinct sessions that saw the resource at least once that day. | `uniq(session_id)` |
+| Metric             | Meaning                                                                                            | Per-day aggregation |
+| ------------------ | -------------------------------------------------------------------------------------------------- | ------------------- |
+| **Impressions**    | Total times the page was loaded and sent an event (includes refreshes, repeat loads same session). | `count()`           |
+| **Unique viewers** | Distinct sessions that saw the resource at least once that day.                                    | `uniq(session_id)`  |
 
 **Single query — daily series for both** (same filter as above):
 
@@ -99,7 +105,7 @@ ORDER BY date;
 ### HTTP API
 
 - **Route:** `POST /api/analytics/view` (or `pageview` if you prefer naming parity with #114).
-- **Body (JSON):** `{ "resource_type": "ARTICLE", "resource_id": "<uuid>", "session_id": "<string>" }`.
+- **Body (JSON):** `{ "resource_type": "ARTICLE", "resource_id": "<uuid>", "session_id": "<string>" }`. The server sets **`session_type`** and the canonical **`session_id`**: if the user is logged in, `session_type = AUTHENTICATED` and `session_id = user id`; otherwise `session_type = ANON` and `session_id` is the client token from the body.
 - **Behavior:** validate allowlist + UUID, insert one row, return **204** quickly. Optionally use **wait_end_of_query: false** (or fire-and-forget pattern) so the client never blocks on ClickHouse latency.
 
 ### Client
@@ -158,12 +164,14 @@ Keep **ownership checks** in one module (e.g. `assertResourceAnalyticsAccess`) s
 
 Add to the server env schema (e.g. `@t3-oss/env-nextjs`):
 
-- `CLICKHOUSE_HOST`
-- `CLICKHOUSE_DATABASE`
+- `CLICKHOUSE_HOST` (hostname only, no protocol)
+- `CLICKHOUSE_PORT` (optional, default `8123` in code)
+- `CLICKHOUSE_DATABASE` (optional, default `default`)
 - `CLICKHOUSE_USERNAME`
 - `CLICKHOUSE_PASSWORD`
+- `CLICKHOUSE_SECURE` — `true` | `false` for `https://` vs `http://`
 
-Optional: `CLICKHOUSE_URL` if using a single connection string provider.
+DDL for the events table lives in `migrations/clickhouse-schema.sql` (run once against the instance).
 
 When vars are missing, ingest route should **no-op or 503** consistently; dashboard should show a clear “analytics unavailable” state so local dev without ClickHouse still runs.
 

--- a/docs/resource-analytics-plan.md
+++ b/docs/resource-analytics-plan.md
@@ -1,0 +1,206 @@
+# Resource analytics plan
+
+This document describes **general resource analytics** for TechDiary: view events and time-series insights for any trackable `(resource_type, resource_id)`, not only articles. It extends the intent of [GitHub issue #114](https://github.com/techdiary-dev/techdiary.dev/issues/114) and the writer-analytics line item in `comeback-strategy.md`.
+
+---
+
+## Goals
+
+- Give **owners** visibility into **reach** (views over time) for content they control.
+- Reuse the same **polymorphic resource keys** the app already uses for reactions, bookmarks, and comments (`resource_type` + `resource_id`).
+- Keep **heavy write traffic** off PostgreSQL by storing view events in **ClickHouse** (or an equivalent columnar/analytics store).
+
+Non-goals for v1:
+
+- Real-time public view counters on every page.
+- Analytics for resources the current user does not own (except future admin tooling).
+- Perfect “read time” without client instrumentation (optional later via scroll/time signals).
+
+---
+
+## Product surface
+
+- **Dashboard (or editor)** entry: “Insights” / “Analytics” for a resource the user owns.
+- **Summary cards:** **impressions** (every append / page load in range) and **unique viewers** (`uniq(session_id)` in range); optional all-time headlines from ClickHouse.
+- **Time-series chart:** primary line = **unique viewers per day**; optional second series or toggle = **impressions per day** (see [Metrics](#metrics-impressions-vs-unique-viewers)). Range **7d / 30d / 90d** (default **30d** per #114).
+- **Engagement from Postgres:** reaction count and bookmark count where the schema supports that `resource_type` (today: **ARTICLE**, **GIST** for reactions; bookmarks per existing `bookmarks` rules).
+
+First consumer: **published article** detail views. Second: **gist** public views, using the same pipeline.
+
+---
+
+## Data model (ClickHouse)
+
+Single events table keyed by resource, not by article only.
+
+```sql
+CREATE TABLE resource_views (
+  resource_type  LowCardinality(String), -- e.g. ARTICLE, GIST (allowlist)
+  resource_id    UUID,
+  viewer_id      Nullable(UUID),         -- NULL when anonymous
+  session_id     String,                 -- stable anonymous bucket (cookie / hash)
+  referrer       Nullable(String),
+  country_code   Nullable(String),       -- optional, from geo later
+  viewed_at      DateTime DEFAULT now()
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(viewed_at)
+ORDER BY (resource_type, resource_id, viewed_at);
+```
+
+**Deduped “views” metric (v1):** `uniq(session_id)` per calendar day per resource, for a chosen window:
+
+```sql
+SELECT
+  toDate(viewed_at) AS date,
+  uniq(session_id)  AS views
+FROM resource_views
+WHERE resource_type = {type:String}
+  AND resource_id = {id:UUID}
+  AND viewed_at >= now() - INTERVAL 30 DAY
+GROUP BY date
+ORDER BY date;
+```
+
+Adjust interval via app-level parameter (7 / 30 / 90 / custom).
+
+### Metrics: impressions vs unique viewers
+
+Append-on-each-load stores **one row per event**. That supports **two KPIs from the same table** without changing ingestion:
+
+| Metric | Meaning | Per-day aggregation |
+|--------|---------|---------------------|
+| **Impressions** | Total times the page was loaded and sent an event (includes refreshes, repeat loads same session). | `count()` |
+| **Unique viewers** | Distinct sessions that saw the resource at least once that day. | `uniq(session_id)` |
+
+**Single query — daily series for both** (same filter as above):
+
+```sql
+SELECT
+  toDate(viewed_at)     AS date,
+  count()               AS impressions,
+  uniq(session_id)      AS unique_viewers
+FROM resource_views
+WHERE resource_type = {type:String}
+  AND resource_id = {id:UUID}
+  AND viewed_at >= now() - INTERVAL 30 DAY
+GROUP BY date
+ORDER BY date;
+```
+
+**Range totals** (summary cards): `sum(impressions)` and `sum(unique_viewers)` over the returned daily rows, or a separate aggregate query with the same `WHERE` and `count()` / `uniq(session_id)` over the whole window (note: `uniq` across the whole window is not the same as summing daily uniques — use **one global `uniq(session_id)`** for “unique viewers in period” if you want strict uniques; use **sum of daily uniques** if you want “approximate reach by day” stacked; document which you show).
+
+**Recommendation for v1 summary:** report **unique viewers in period** as `uniq(session_id)` with the date filter only (one number), and **impressions in period** as `count()` with the same filter.
+
+---
+
+## Ingestion
+
+### HTTP API
+
+- **Route:** `POST /api/analytics/view` (or `pageview` if you prefer naming parity with #114).
+- **Body (JSON):** `{ "resource_type": "ARTICLE", "resource_id": "<uuid>", "session_id": "<string>" }`.
+- **Behavior:** validate allowlist + UUID, insert one row, return **204** quickly. Optionally use **wait_end_of_query: false** (or fire-and-forget pattern) so the client never blocks on ClickHouse latency.
+
+### Client
+
+- **Fire-and-forget** `fetch` on the **public** resource page (article read, gist read) inside a small client component mounted once per page.
+- **Session id:** anonymous stable id from a long-lived cookie or `localStorage` + fallback; if logged in, still send `session_id` for dedupe and optionally set `viewer_id` from server-side context if the route chooses to enrich (or leave enrichment to a later iteration).
+
+### Allowlist
+
+Reject unknown `resource_type` values at the API to avoid garbage dimensions. Start with: `ARTICLE`, `GIST`. Expand deliberately (e.g. `SERIES`) when there is a clear owner and a public URL.
+
+### Abuse / noise
+
+- Rate limit by IP at the edge or in the route (follow existing API patterns).
+- Optional: drop obvious bots via `User-Agent` heuristics later.
+
+---
+
+## Read path (server)
+
+### Server action (or cached query helper)
+
+- **Name:** e.g. `getResourceAnalytics({ resource_type, resource_id, rangeDays })`.
+- **Steps:**
+  1. Resolve current user (`authID()`).
+  2. **Assert ownership** for `(resource_type, resource_id)` via a small internal map:
+     - `ARTICLE` → author_id matches user.
+     - `GIST` → owner matches user.
+     - (Future types → same pattern.)
+  3. Run the ClickHouse aggregation query.
+  4. Optionally merge **reaction** / **bookmark** counts from SQLKit repositories for that resource.
+
+Return a typed payload, e.g. `{ series: { date, impressions, unique_viewers }[], totals: { impressions, unique_viewers }, reactions: number, bookmarks: number }` (shape can evolve). Chart can default to **unique viewers** with impressions as secondary or toggle.
+
+**Caching:** read-only, user-specific data — **do not** use `'use cache'` on functions that call `cookies()` / session. Per-request or short-lived client cache (TanStack Query) is appropriate.
+
+---
+
+## Code layout (suggested)
+
+| Area                        | Path / artifact                                                                                                                    |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| ClickHouse client singleton | `src/backend/persistence/clickhouse.client.ts`                                                                                     |
+| Analytics server actions    | `src/backend/services/analytics.actions.ts`                                                                                        |
+| Zod input                   | `src/backend/services/inputs/analytics.input.ts`                                                                                   |
+| Ingest route                | `src/app/api/analytics/view/route.ts`                                                                                              |
+| Client tracker              | e.g. `src/components/analytics/ResourceViewTracker.tsx`                                                                            |
+| Chart                       | e.g. `src/components/analytics/ResourceAnalyticsChart.tsx` (Recharts or existing chart lib)                                        |
+| Dashboard page              | e.g. `src/app/(dashboard-editor)/dashboard/analytics/[resourceType]/[resourceId]/page.tsx` or nested under article/gist edit flows |
+
+Keep **ownership checks** in one module (e.g. `assertResourceAnalyticsAccess`) so new resource types only add a branch there.
+
+---
+
+## Environment variables
+
+Add to the server env schema (e.g. `@t3-oss/env-nextjs`):
+
+- `CLICKHOUSE_HOST`
+- `CLICKHOUSE_DATABASE`
+- `CLICKHOUSE_USERNAME`
+- `CLICKHOUSE_PASSWORD`
+
+Optional: `CLICKHOUSE_URL` if using a single connection string provider.
+
+When vars are missing, ingest route should **no-op or 503** consistently; dashboard should show a clear “analytics unavailable” state so local dev without ClickHouse still runs.
+
+---
+
+## Dependencies
+
+- `@clickhouse/client` — official client for insert/query.
+
+---
+
+## Rollout order
+
+1. Provision ClickHouse (Cloud or Docker) and create `resource_views`.
+2. Add env vars + `clickhouse.client.ts` + connection health check (optional).
+3. Implement `POST /api/analytics/view` with allowlist validation.
+4. Add `ResourceViewTracker` to **published article** page (and optionally gist page).
+5. Implement `getResourceAnalytics` + ownership assertions.
+6. Build dashboard UI: summary cards (**impressions** + **unique viewers**) + range toggle + chart (unique viewers primary; impressions optional second series or toggle).
+7. Wire entry points from article editor / dashboard nav.
+8. Production monitoring: insert errors, query latency, row growth.
+
+---
+
+## Relationship to PostgreSQL
+
+- **Authoritative for identity and engagement:** users, articles, gists, reactions, bookmarks remain in Postgres.
+- **Analytics store:** append-only view events; cheap `count()` and `uniq(session_id)` per day.
+- **Issue #114 acceptance criteria** map as follows:
+  - View count / time series → ClickHouse: **unique viewers** time series (`uniq(session_id)` by day); **impressions** (`count()` by day) from the same rows.
+  - Reaction and bookmark counts → existing repositories by `resource_type` / `resource_id`.
+  - “Estimated reads” → future enhancement (scroll depth, time-on-page); not required for v1.
+
+---
+
+## Open decisions
+
+- **Public view counter:** whether to show aggregate views on the article page (requires either a cached aggregate job or a separate materialized summary).
+- **GDPR / retention:** retention window for `resource_views` and deletion story when a user or resource is removed (ClickHouse TTL or periodic cleanup).
+- **Cross-resource dashboard:** one page listing “all my content” with sparklines — nice follow-up after single-resource insights ship.

--- a/migrations/clickhouse-schema.sql
+++ b/migrations/clickhouse-schema.sql
@@ -1,0 +1,14 @@
+-- Run once against your ClickHouse instance (e.g. clickhouse-client or HTTP POST to :8123).
+-- session_type: ANON = client token in session_id; AUTHENTICATED = user id (UUID string) in session_id.
+CREATE TABLE IF NOT EXISTS resource_views (
+  resource_type   LowCardinality(String),
+  resource_id     UUID,
+  session_type    LowCardinality(String),
+  session_id      String,
+  referrer        Nullable(String),
+  country_code    Nullable(String),
+  viewed_at       DateTime DEFAULT now()
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(viewed_at)
+ORDER BY (resource_type, resource_id, viewed_at);

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.828.0",
     "@aws-sdk/s3-request-presigner": "^3.828.0",
+    "@clickhouse/client": "^1.18.2",
     "@cloudinary/react": "^1.14.1",
     "@cloudinary/url-gen": "^1.21.0",
     "@codesandbox/sandpack-react": "^2.20.0",

--- a/src/app/[username]/[articleHandle]/page.tsx
+++ b/src/app/[username]/[articleHandle]/page.tsx
@@ -22,6 +22,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import type { Article, WithContext } from "schema-dts";
 import { eq } from "sqlkit";
+import { ResourceViewTracker } from "@/components/analytics/ResourceViewTracker";
 import ArticleSidebar from "./_components/ArticleSidebar";
 import EditArticleButton from "./_components/EditArticleButton";
 import {
@@ -130,6 +131,9 @@ const Page: NextPage<ArticlePageProps> = async ({ params }) => {
 
   return (
     <>
+      {article.published_at ? (
+        <ResourceViewTracker resourceType="ARTICLE" resourceId={article.id} />
+      ) : null}
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
@@ -197,7 +201,9 @@ const Page: NextPage<ArticlePageProps> = async ({ params }) => {
                   <ArticleDraftBylineLabel />
                 )}
                 <span className="mx-1.5">·</span>
-                <ArticleReadingTime minutes={readingTime(article?.body ?? "")} />
+                <ArticleReadingTime
+                  minutes={readingTime(article?.body ?? "")}
+                />
               </div>
             </div>
           </div>

--- a/src/app/api/analytics/view/route.ts
+++ b/src/app/api/analytics/view/route.ts
@@ -1,0 +1,63 @@
+import { getClickHouseClient, isClickHouseConfigured } from "@/backend/persistence/clickhouse.client";
+import { AnalyticsInput } from "@/backend/services/inputs/analytics.input";
+import { authID } from "@/backend/services/session.actions";
+import { NextResponse } from "next/server";
+
+/**
+ * Records one resource view event (append-only). No-ops with 204 when ClickHouse is not configured.
+ */
+export async function POST(req: Request) {
+  if (!isClickHouseConfigured()) {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  const client = getClickHouseClient();
+  if (!client) {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const parsed = await AnalyticsInput.recordViewBody.safeParseAsync(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues.map((i) => i.message).join(", ") },
+      { status: 400 },
+    );
+  }
+
+  const userId = await authID();
+  const referrer = req.headers.get("referer");
+
+  const session =
+    userId != null
+      ? { session_type: "AUTHENTICATED" as const, session_id: userId }
+      : { session_type: "ANON" as const, session_id: parsed.data.session_id };
+
+  try {
+    await client.insert({
+      table: "resource_views",
+      values: [
+        {
+          resource_type: parsed.data.resource_type,
+          resource_id: parsed.data.resource_id,
+          session_type: session.session_type,
+          session_id: session.session_id,
+          referrer: referrer ? referrer.slice(0, 2048) : null,
+          country_code: null,
+        },
+      ],
+      format: "JSONEachRow",
+    });
+  } catch (e) {
+    console.error("[analytics/view] ClickHouse insert failed:", e);
+    return new NextResponse(null, { status: 500 });
+  }
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/app/dashboard/_components/DashboardAnalyticsOverview.tsx
+++ b/src/app/dashboard/_components/DashboardAnalyticsOverview.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import * as React from "react";
+import { getDashboardAnalyticsOverview } from "@/backend/services/analytics.actions";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import { useTranslation } from "@/i18n/use-translation";
+import { actionPromisify } from "@/lib/utils";
+import { useQuery } from "@tanstack/react-query";
+import { CartesianGrid, Line, LineChart, XAxis } from "recharts";
+import {
+  AnalyticsRangeControls,
+  analyticsTimeRangeToQueryPayload,
+  type AnalyticsTimeRange,
+} from "@/components/analytics/AnalyticsRangeControls";
+
+const chartConfig = {
+  unique_viewers: {
+    label: "Unique viewers",
+    color: "hsl(var(--chart-1))",
+  },
+  impressions: {
+    label: "Impressions",
+    color: "hsl(var(--chart-2))",
+  },
+} satisfies ChartConfig;
+
+export default function DashboardAnalyticsOverview() {
+  const { _t } = useTranslation();
+  const [timeRange, setTimeRange] = React.useState<AnalyticsTimeRange>({
+    kind: "preset",
+    days: 30,
+  });
+
+  const rangePayload = analyticsTimeRangeToQueryPayload(timeRange);
+
+  const query = useQuery({
+    queryKey: ["dashboard-analytics-overview", rangePayload],
+    queryFn: () =>
+      actionPromisify(getDashboardAnalyticsOverview({ ...rangePayload })),
+  });
+
+  if (query.isPending) {
+    return (
+      <section id="dashboard-analytics" className="mb-10 space-y-4 scroll-mt-4">
+        <div className="h-8 w-48 animate-pulse rounded-md bg-muted" />
+        <div className="h-24 animate-pulse rounded-lg bg-muted" />
+        <div className="h-[300px] animate-pulse rounded-lg bg-muted" />
+      </section>
+    );
+  }
+
+  if (query.isError) {
+    return (
+      <section id="dashboard-analytics" className="mb-10 scroll-mt-4">
+        <p className="text-sm text-destructive">
+          {query.error instanceof Error ? query.error.message : String(query.error)}
+        </p>
+      </section>
+    );
+  }
+
+  const data = query.data;
+  const chartData = data.series.map((row) => ({
+    ...row,
+    dateLabel: row.date.slice(5),
+  }));
+
+  const hasTrackedResources =
+    data.publishedArticleCount > 0 || data.publicGistCount > 0;
+
+  return (
+    <section id="dashboard-analytics" className="mb-10 scroll-mt-4">
+      <div className="mb-4 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold tracking-tight">
+            {_t("Reach & views")}
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            {_t("Across your published articles and public gists")} (
+            {data.publishedArticleCount}{" "}
+            {data.publishedArticleCount === 1 ? _t("article") : _t("articles")}
+            {", "}
+            {data.publicGistCount}{" "}
+            {data.publicGistCount === 1 ? _t("gist") : _t("gists")}).{" "}
+            <span className="text-foreground/80">
+              {_t("Use Article analytics on each published row for a single post.")}
+            </span>
+          </p>
+        </div>
+        <AnalyticsRangeControls value={timeRange} onChange={setTimeRange} />
+      </div>
+
+      {!data.clickhouseConfigured ? (
+        <p className="mb-4 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-950 dark:text-amber-100">
+          {_t(
+            "View analytics are not configured (ClickHouse env missing). Totals below show reactions and bookmarks from the database only.",
+          )}
+        </p>
+      ) : null}
+
+      {data.clickhouseConfigured && !hasTrackedResources ? (
+        <p className="mb-4 rounded-md border border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
+          {_t(
+            "Publish an article or create a public gist to start collecting view analytics.",
+          )}
+        </p>
+      ) : null}
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <Card className="rounded-lg border shadow-none">
+          <CardHeader className="pb-2">
+            <CardDescription>{_t("Unique viewers")}</CardDescription>
+            <CardTitle className="text-2xl tabular-nums">
+              {data.totals.unique_viewers}
+            </CardTitle>
+          </CardHeader>
+        </Card>
+        <Card className="rounded-lg border shadow-none">
+          <CardHeader className="pb-2">
+            <CardDescription>{_t("Impressions")}</CardDescription>
+            <CardTitle className="text-2xl tabular-nums">
+              {data.totals.impressions}
+            </CardTitle>
+          </CardHeader>
+        </Card>
+        <Card className="rounded-lg border shadow-none">
+          <CardHeader className="pb-2">
+            <CardDescription>{_t("Reactions")}</CardDescription>
+            <CardTitle className="text-2xl tabular-nums">{data.reactions}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card className="rounded-lg border shadow-none">
+          <CardHeader className="pb-2">
+            <CardDescription>{_t("Bookmarks")}</CardDescription>
+            <CardTitle className="text-2xl tabular-nums">{data.bookmarks}</CardTitle>
+          </CardHeader>
+        </Card>
+      </div>
+
+      <Card className="mt-4 rounded-lg border shadow-none">
+        <CardHeader>
+          <CardTitle className="text-base">{_t("Views over time")}</CardTitle>
+          <CardDescription>
+            {_t("Stacked across everything you track in this dashboard")}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {!data.clickhouseConfigured || !hasTrackedResources ? (
+            <p className="text-sm text-muted-foreground">
+              {_t("Chart appears when view tracking is available for your content.")}
+            </p>
+          ) : chartData.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              {_t("No view data in this range yet.")}
+            </p>
+          ) : (
+            <ChartContainer config={chartConfig} className="h-[min(320px,50vh)] w-full">
+              <LineChart
+                accessibilityLayer
+                data={chartData}
+                margin={{ left: 8, right: 8, top: 8, bottom: 0 }}
+              >
+                <CartesianGrid vertical={false} />
+                <XAxis
+                  dataKey="dateLabel"
+                  tickLine={false}
+                  axisLine={false}
+                  tickMargin={8}
+                />
+                <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
+                <ChartLegend content={<ChartLegendContent />} />
+                <Line
+                  type="monotone"
+                  dataKey="unique_viewers"
+                  stroke="var(--color-unique_viewers)"
+                  strokeWidth={2}
+                  dot={false}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="impressions"
+                  stroke="var(--color-impressions)"
+                  strokeWidth={2}
+                  dot={false}
+                />
+              </LineChart>
+            </ChartContainer>
+          )}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/src/app/dashboard/_components/DashboardArticleList.tsx
+++ b/src/app/dashboard/_components/DashboardArticleList.tsx
@@ -29,7 +29,7 @@ import {
 } from "@tanstack/react-query";
 import clsx from "clsx";
 import { addDays, differenceInHours } from "date-fns";
-import { TrashIcon } from "lucide-react";
+import { LineChartIcon, TrashIcon } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 
@@ -257,7 +257,7 @@ const DashboardArticleList = () => {
               </div>
 
               <div className="flex items-center gap-10 justify-between">
-                <div className="flex gap-4 items-center">
+                <div className="flex flex-wrap gap-3 items-center">
                   {!Boolean(article?.published_at) && (
                     <p className="bg-yellow-400/30 rounded-sm px-2 py-1 text-sm">
                       🚧 {_t("Draft")}
@@ -269,6 +269,16 @@ const DashboardArticleList = () => {
                       ✅ {_t("Published")}
                     </p>
                   )}
+
+                  {Boolean(article?.published_at) ? (
+                    <Link
+                      href={`/dashboard/analytics/article/${article.id}`}
+                      className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-sm font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:text-foreground"
+                    >
+                      <LineChartIcon className="size-4 shrink-0" />
+                      {_t("Article analytics")}
+                    </Link>
+                  ) : null}
                 </div>
                 <DropdownMenu>
                   <DropdownMenuTrigger className="flex items-center gap-2">
@@ -285,6 +295,18 @@ const DashboardArticleList = () => {
                         <span>{_t("Edit")}</span>
                       </Link>
                     </DropdownMenuItem>
+
+                    {Boolean(article?.published_at) ? (
+                      <DropdownMenuItem asChild>
+                        <Link
+                          href={`/dashboard/analytics/article/${article.id}`}
+                          className="text-foreground"
+                        >
+                          <LineChartIcon className="size-4" />
+                          <span>{_t("Analytics")}</span>
+                        </Link>
+                      </DropdownMenuItem>
+                    ) : null}
 
                     <DropdownMenuItem asChild>
                       <button

--- a/src/app/dashboard/_components/DashboardSidebar.tsx
+++ b/src/app/dashboard/_components/DashboardSidebar.tsx
@@ -16,6 +16,7 @@ import {
   Bookmark,
   Home,
   KeySquareIcon,
+  LineChart,
   Settings2,
 } from "lucide-react";
 import Link from "next/link";
@@ -30,6 +31,11 @@ const DashboardSidebar = () => {
       title: _t("Dashboard"),
       url: "",
       icon: Home,
+    },
+    {
+      title: _t("Reach"),
+      url: "/dashboard#dashboard-analytics",
+      icon: LineChart,
     },
     // {
     //   title: _t("Series"),
@@ -59,15 +65,23 @@ const DashboardSidebar = () => {
           <SidebarGroupLabel>{_t("Dashboard")}</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              {items.slice(0, 1).map((item, key) => (
+              {items.slice(0, 2).map((item, key) => (
                 <SidebarMenuItem key={key}>
                   <SidebarMenuButton
                     asChild
-                    isActive={pathName === `/dashboard${item.url}`}
+                    isActive={
+                      item.url.startsWith("#")
+                        ? false
+                        : pathName === `/dashboard${item.url}`
+                    }
                   >
                     <Link
                       className="text-muted-foreground"
-                      href={`/dashboard${item.url}`}
+                      href={
+                        item.url.startsWith("/dashboard#")
+                          ? item.url
+                          : `/dashboard${item.url}`
+                      }
                     >
                       <item.icon />
                       <span>{item.title}</span>
@@ -79,7 +93,7 @@ const DashboardSidebar = () => {
                 pathName={pathName}
                 label={_t("Notifications")}
               />
-              {items.slice(1).map((item, key) => (
+              {items.slice(2).map((item, key) => (
                 <SidebarMenuItem key={`rest-${key}`}>
                   <SidebarMenuButton
                     asChild

--- a/src/app/dashboard/analytics/[kind]/[resourceId]/page.tsx
+++ b/src/app/dashboard/analytics/[kind]/[resourceId]/page.tsx
@@ -1,0 +1,149 @@
+import { ResourceAnalyticsDashboard } from "@/components/analytics/ResourceAnalyticsDashboard";
+import type { TrackedResourceType } from "@/backend/services/inputs/analytics.input";
+import { persistenceRepository } from "@/backend/persistence/persistence-repositories";
+import { DatabaseTableName } from "@/backend/persistence/persistence-contracts";
+import * as sessionActions from "@/backend/services/session.actions";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { and, eq } from "sqlkit";
+import { z } from "zod/v4";
+
+const KIND_MAP: Record<string, TrackedResourceType> = {
+  article: "ARTICLE",
+  gist: "GIST",
+};
+
+interface Props {
+  params: Promise<{ kind: string; resourceId: string }>;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { kind, resourceId } = await params;
+  const resourceType = KIND_MAP[kind];
+  if (!resourceType || !z.string().uuid().safeParse(resourceId).success) {
+    return { title: "Analytics" };
+  }
+
+  const userId = await sessionActions.authID();
+  if (!userId) {
+    return { title: "Analytics" };
+  }
+
+  if (kind === "article") {
+    const [row] = await persistenceRepository.article.find({
+      limit: 1,
+      columns: ["title"],
+      where: and(eq("id", resourceId), eq("author_id", userId)),
+    });
+    return {
+      title: row?.title ? `${row.title} — Analytics` : "Article analytics",
+    };
+  }
+
+  if (kind === "gist") {
+    const [row] = await persistenceRepository.gist.find({
+      limit: 1,
+      columns: ["title"],
+      where: and(eq("id", resourceId), eq("owner_id", userId)),
+    });
+    return {
+      title: row?.title ? `${row.title} — Analytics` : "Gist analytics",
+    };
+  }
+
+  return { title: "Analytics" };
+}
+
+export default async function ResourceAnalyticsPage({ params }: Props) {
+  const { kind, resourceId } = await params;
+
+  const resourceType = KIND_MAP[kind];
+  if (!resourceType) {
+    notFound();
+  }
+
+  if (!z.string().uuid().safeParse(resourceId).success) {
+    notFound();
+  }
+
+  const sessionUserId = await sessionActions.authID();
+  if (!sessionUserId) {
+    redirect(`/login?next=/dashboard/analytics/${kind}/${resourceId}`);
+  }
+
+  let resourceTitle: string | null = null;
+  let publicReaderHref: string | null = null;
+  const backHref =
+    kind === "article"
+      ? `/dashboard/articles/${resourceId}`
+      : `/gists/${resourceId}/edit`;
+
+  if (kind === "article") {
+    const [article] = await persistenceRepository.article.find({
+      limit: 1,
+      columns: ["title", "handle"],
+      where: and(eq("id", resourceId), eq("author_id", sessionUserId)),
+      joins: [
+        {
+          as: "user",
+          table: DatabaseTableName.users,
+          type: "left",
+          on: {
+            localField: "author_id",
+            foreignField: "id",
+          },
+          columns: ["username"],
+        },
+      ],
+    });
+    if (!article) {
+      notFound();
+    }
+    resourceTitle = article.title;
+    const username = article.user?.username;
+    if (username && article.handle) {
+      publicReaderHref = `/${username}/${article.handle}`;
+    }
+  } else {
+    const [gist] = await persistenceRepository.gist.find({
+      limit: 1,
+      columns: ["title", "is_public"],
+      where: and(eq("id", resourceId), eq("owner_id", sessionUserId)),
+    });
+    if (!gist) {
+      notFound();
+    }
+    resourceTitle = gist.title;
+    if (gist.is_public) {
+      publicReaderHref = `/gists/${resourceId}`;
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-4 md:p-6">
+      <Link
+        href={backHref}
+        className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        ← Back
+      </Link>
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">
+          {kind === "gist" ? "Gist analytics" : "Article analytics"}
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {kind === "gist"
+            ? "Reach and engagement for this gist."
+            : "Reach and engagement for this article."}
+        </p>
+      </div>
+      <ResourceAnalyticsDashboard
+        resourceType={resourceType}
+        resourceId={resourceId}
+        resourceTitle={resourceTitle}
+        publicReaderHref={publicReaderHref}
+      />
+    </div>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,11 +1,11 @@
+import DashboardAnalyticsOverview from "./_components/DashboardAnalyticsOverview";
 import DashboardArticleList from "./_components/DashboardArticleList";
 import MatrixReport from "./_components/MatrixReport";
-// import ViewsChart from "./_components/ViewsChart";
 
 const page = () => {
   return (
     <>
-      {/* <ViewsChart /> */}
+      <DashboardAnalyticsOverview />
       <MatrixReport />
       <DashboardArticleList />
     </>

--- a/src/backend/persistence/clickhouse.client.ts
+++ b/src/backend/persistence/clickhouse.client.ts
@@ -1,0 +1,41 @@
+import { createClient, type ClickHouseClient } from "@clickhouse/client";
+import { env } from "@/env";
+
+declare global {
+  var __clickhouseClient: ClickHouseClient | undefined;
+}
+
+export function isClickHouseConfigured(): boolean {
+  return Boolean(
+    env.CLICKHOUSE_HOST &&
+      env.CLICKHOUSE_USERNAME &&
+      env.CLICKHOUSE_PASSWORD,
+  );
+}
+
+function buildClickHouseUrl(): string {
+  const host = env.CLICKHOUSE_HOST!;
+  const port = env.CLICKHOUSE_PORT ?? "8123";
+  const secure = env.CLICKHOUSE_SECURE === "true";
+  return `${secure ? "https" : "http"}://${host}:${port}`;
+}
+
+/**
+ * Singleton HTTP client. Returns null when ClickHouse env is not set (local dev without analytics).
+ */
+export function getClickHouseClient(): ClickHouseClient | null {
+  if (!isClickHouseConfigured()) {
+    return null;
+  }
+
+  if (!globalThis.__clickhouseClient) {
+    globalThis.__clickhouseClient = createClient({
+      url: buildClickHouseUrl(),
+      username: env.CLICKHOUSE_USERNAME!,
+      password: env.CLICKHOUSE_PASSWORD!,
+      database: env.CLICKHOUSE_DATABASE ?? "default",
+    });
+  }
+
+  return globalThis.__clickhouseClient;
+}

--- a/src/backend/services/analytics.actions.ts
+++ b/src/backend/services/analytics.actions.ts
@@ -1,0 +1,439 @@
+"use server";
+
+import { z } from "zod/v4";
+import { and, eq, isNotNull } from "sqlkit";
+import { getClickHouseClient, isClickHouseConfigured } from "../persistence/clickhouse.client";
+import { persistenceRepository } from "../persistence/persistence-repositories";
+import { pgClient } from "../persistence/clients";
+import { ActionException, handleActionException } from "./RepositoryException";
+import { authID } from "./session.actions";
+import {
+  AnalyticsInput,
+  type TrackedResourceType,
+} from "./inputs/analytics.input";
+import type { ActionResponse } from "../models/action-contracts";
+
+const sql = String.raw;
+
+export type ResourceAnalyticsDayRow = {
+  date: string;
+  impressions: number;
+  unique_viewers: number;
+};
+
+export type ResourceAnalyticsData = {
+  series: ResourceAnalyticsDayRow[];
+  totals: {
+    impressions: number;
+    unique_viewers: number;
+  };
+  reactions: number;
+  bookmarks: number;
+  clickhouseConfigured: boolean;
+};
+
+export type DashboardAnalyticsOverviewData = ResourceAnalyticsData & {
+  publishedArticleCount: number;
+  publicGistCount: number;
+};
+
+const MAX_TRACKED_ARTICLES = 500;
+const MAX_TRACKED_GISTS = 200;
+const MAX_CUSTOM_RANGE_MS = 366 * 86400000;
+
+type ClickHouseTimeFilter =
+  | { kind: "preset"; days: number }
+  | {
+      kind: "custom";
+      range_start: string;
+      range_end_exclusive: string;
+    };
+
+function resolveClickHouseTimeFilter(payload: {
+  range_days?: number;
+  start_date?: string;
+  end_date?: string;
+}): ClickHouseTimeFilter {
+  if (payload.start_date && payload.end_date) {
+    const start = new Date(`${payload.start_date}T00:00:00.000Z`);
+    const endInclusive = new Date(`${payload.end_date}T00:00:00.000Z`);
+    if (Number.isNaN(start.getTime()) || Number.isNaN(endInclusive.getTime())) {
+      throw new ActionException("Invalid date range");
+    }
+    const endExclusive = new Date(endInclusive);
+    endExclusive.setUTCDate(endExclusive.getUTCDate() + 1);
+    const span = endExclusive.getTime() - start.getTime();
+    if (span <= 0) {
+      throw new ActionException("Invalid date range");
+    }
+    if (span > MAX_CUSTOM_RANGE_MS) {
+      throw new ActionException("Custom range cannot exceed 366 days");
+    }
+    const fmt = (d: Date) => d.toISOString().slice(0, 19).replace("T", " ");
+    return {
+      kind: "custom",
+      range_start: fmt(start),
+      range_end_exclusive: fmt(endExclusive),
+    };
+  }
+  const days = payload.range_days ?? 30;
+  return { kind: "preset", days };
+}
+
+function clickHouseTimePredicate(filter: ClickHouseTimeFilter): string {
+  return filter.kind === "preset"
+    ? "viewed_at >= now() - INTERVAL {days:UInt32} DAY"
+    : "viewed_at >= parseDateTimeBestEffort({range_start:String}) AND viewed_at < parseDateTimeBestEffort({range_end_exclusive:String})";
+}
+
+function clickHouseTimeParams(filter: ClickHouseTimeFilter): Record<string, string | number> {
+  if (filter.kind === "preset") {
+    return { days: filter.days };
+  }
+  return {
+    range_start: filter.range_start,
+    range_end_exclusive: filter.range_end_exclusive,
+  };
+}
+
+function buildClickHouseResourceFilter(articleIds: string[], gistIds: string[]) {
+  const parts: string[] = [];
+  const extra: Record<string, string[]> = {};
+  if (articleIds.length > 0) {
+    parts.push(`(resource_type = 'ARTICLE' AND resource_id IN {article_ids:Array(UUID)})`);
+    extra.article_ids = articleIds;
+  }
+  if (gistIds.length > 0) {
+    parts.push(`(resource_type = 'GIST' AND resource_id IN {gist_ids:Array(UUID)})`);
+    extra.gist_ids = gistIds;
+  }
+  return { parts, extra };
+}
+
+async function assertResourceAnalyticsAccess(
+  userId: string,
+  resourceType: TrackedResourceType,
+  resourceId: string,
+) {
+  if (resourceType === "ARTICLE") {
+    const [row] = await persistenceRepository.article.find({
+      limit: 1,
+      columns: ["id"],
+      where: and(eq("id", resourceId), eq("author_id", userId)),
+    });
+    if (!row) {
+      throw new ActionException("Forbidden");
+    }
+    return;
+  }
+
+  if (resourceType === "GIST") {
+    const [row] = await persistenceRepository.gist.find({
+      limit: 1,
+      columns: ["id"],
+      where: and(eq("id", resourceId), eq("owner_id", userId)),
+    });
+    if (!row) {
+      throw new ActionException("Forbidden");
+    }
+  }
+}
+
+async function countReactionsRaw(resourceId: string, resourceType: string) {
+  const q = sql`
+    SELECT COUNT(*)::int AS c FROM reactions
+    WHERE resource_id = $1 AND resource_type = $2
+  `;
+  const res = await pgClient.executeSQL(q, [resourceId, resourceType]);
+  const row = res?.rows?.[0] as { c?: number } | undefined;
+  return Number(row?.c ?? 0);
+}
+
+async function countBookmarksRaw(resourceId: string, resourceType: string) {
+  const q = sql`
+    SELECT COUNT(*)::int AS c FROM bookmarks
+    WHERE resource_id = $1 AND resource_type = $2
+  `;
+  const res = await pgClient.executeSQL(q, [resourceId, resourceType]);
+  const row = res?.rows?.[0] as { c?: number } | undefined;
+  return Number(row?.c ?? 0);
+}
+
+export async function getResourceAnalytics(
+  input: z.infer<typeof AnalyticsInput.getResourceAnalyticsInput>,
+): Promise<ActionResponse<ResourceAnalyticsData>> {
+  try {
+    const payload = await AnalyticsInput.getResourceAnalyticsInput.parseAsync(input);
+    const userId = await authID();
+    if (!userId) {
+      throw new ActionException("Unauthorized");
+    }
+
+    await assertResourceAnalyticsAccess(
+      userId,
+      payload.resource_type,
+      payload.resource_id,
+    );
+
+    const [reactions, bookmarks] = await Promise.all([
+      countReactionsRaw(payload.resource_id, payload.resource_type),
+      payload.resource_type === "GIST"
+        ? Promise.resolve(0)
+        : countBookmarksRaw(payload.resource_id, payload.resource_type),
+    ]);
+
+    const chConfigured = isClickHouseConfigured();
+    const client = getClickHouseClient();
+
+    if (!chConfigured || !client) {
+      return {
+        success: true,
+        data: {
+          series: [],
+          totals: { impressions: 0, unique_viewers: 0 },
+          reactions,
+          bookmarks,
+          clickhouseConfigured: false,
+        },
+      };
+    }
+
+    const timeFilter = resolveClickHouseTimeFilter(payload);
+    const timePred = clickHouseTimePredicate(timeFilter);
+    const params = {
+      type: payload.resource_type,
+      id: payload.resource_id,
+      ...clickHouseTimeParams(timeFilter),
+    };
+
+    const [seriesResult, totalsResult] = await Promise.all([
+      client.query({
+        query: `
+          SELECT
+            toDate(viewed_at) AS date,
+            toUInt64(count()) AS impressions,
+            toUInt64(uniq(session_id)) AS unique_viewers
+          FROM resource_views
+          WHERE resource_type = {type:String}
+            AND resource_id = {id:UUID}
+            AND (${timePred})
+          GROUP BY date
+          ORDER BY date
+        `,
+        query_params: params,
+        format: "JSONEachRow",
+      }),
+      client.query({
+        query: `
+          SELECT
+            toUInt64(count()) AS impressions,
+            toUInt64(uniq(session_id)) AS unique_viewers
+          FROM resource_views
+          WHERE resource_type = {type:String}
+            AND resource_id = {id:UUID}
+            AND (${timePred})
+        `,
+        query_params: params,
+        format: "JSONEachRow",
+      }),
+    ]);
+
+    const seriesRows = (await seriesResult.json()) as Array<{
+      date: string;
+      impressions: string | number;
+      unique_viewers: string | number;
+    }>;
+
+    const totalsRows = (await totalsResult.json()) as Array<{
+      impressions: string | number;
+      unique_viewers: string | number;
+    }>;
+
+    const totalsRow = totalsRows[0];
+
+    return {
+      success: true,
+      data: {
+        series: seriesRows.map((r) => ({
+          date: String(r.date),
+          impressions: Number(r.impressions),
+          unique_viewers: Number(r.unique_viewers),
+        })),
+        totals: {
+          impressions: Number(totalsRow?.impressions ?? 0),
+          unique_viewers: Number(totalsRow?.unique_viewers ?? 0),
+        },
+        reactions,
+        bookmarks,
+        clickhouseConfigured: true,
+      },
+    };
+  } catch (error) {
+    return handleActionException(error);
+  }
+}
+
+async function countReactionsForResources(articleIds: string[], gistIds: string[]) {
+  const q = sql`
+    SELECT COUNT(*)::int AS c FROM reactions
+    WHERE
+      (resource_type = 'ARTICLE' AND resource_id = ANY($1::uuid[]))
+      OR (resource_type = 'GIST' AND resource_id = ANY($2::uuid[]))
+  `;
+  const res = await pgClient.executeSQL(q, [articleIds, gistIds]);
+  const row = res?.rows?.[0] as { c?: number } | undefined;
+  return Number(row?.c ?? 0);
+}
+
+async function countBookmarksForArticles(articleIds: string[]) {
+  const q = sql`
+    SELECT COUNT(*)::int AS c FROM bookmarks
+    WHERE resource_type = 'ARTICLE' AND resource_id = ANY($1::uuid[])
+  `;
+  const res = await pgClient.executeSQL(q, [articleIds]);
+  const row = res?.rows?.[0] as { c?: number } | undefined;
+  return Number(row?.c ?? 0);
+}
+
+/**
+ * Aggregated view analytics across the current user's published articles and public gists.
+ */
+export async function getDashboardAnalyticsOverview(
+  input: z.infer<typeof AnalyticsInput.getDashboardAnalyticsOverviewInput>,
+): Promise<ActionResponse<DashboardAnalyticsOverviewData>> {
+  try {
+    const payload = await AnalyticsInput.getDashboardAnalyticsOverviewInput.parseAsync(input);
+    const userId = await authID();
+    if (!userId) {
+      throw new ActionException("Unauthorized");
+    }
+
+    const [articleRows, gistRows] = await Promise.all([
+      persistenceRepository.article.find({
+        where: and(eq("author_id", userId), isNotNull("published_at")),
+        columns: ["id"],
+        limit: MAX_TRACKED_ARTICLES,
+      }),
+      persistenceRepository.gist.find({
+        where: and(eq("owner_id", userId), eq("is_public", true)),
+        columns: ["id"],
+        limit: MAX_TRACKED_GISTS,
+      }),
+    ]);
+
+    const articleIds = articleRows.map((a) => a.id);
+    const gistIds = gistRows.map((g) => g.id);
+
+    const [reactions, bookmarks] = await Promise.all([
+      countReactionsForResources(articleIds, gistIds),
+      countBookmarksForArticles(articleIds),
+    ]);
+
+    const chConfigured = isClickHouseConfigured();
+    const client = getClickHouseClient();
+    const { parts, extra } = buildClickHouseResourceFilter(articleIds, gistIds);
+
+    if (!chConfigured || !client) {
+      return {
+        success: true,
+        data: {
+          series: [],
+          totals: { impressions: 0, unique_viewers: 0 },
+          reactions,
+          bookmarks,
+          clickhouseConfigured: false,
+          publishedArticleCount: articleIds.length,
+          publicGistCount: gistIds.length,
+        },
+      };
+    }
+
+    if (parts.length === 0) {
+      return {
+        success: true,
+        data: {
+          series: [],
+          totals: { impressions: 0, unique_viewers: 0 },
+          reactions,
+          bookmarks,
+          clickhouseConfigured: true,
+          publishedArticleCount: articleIds.length,
+          publicGistCount: gistIds.length,
+        },
+      };
+    }
+
+    const resourceWhere = parts.join(" OR ");
+    const timeFilter = resolveClickHouseTimeFilter(payload);
+    const timePred = clickHouseTimePredicate(timeFilter);
+    const baseParams = {
+      ...extra,
+      ...clickHouseTimeParams(timeFilter),
+    };
+
+    const [seriesResult, totalsResult] = await Promise.all([
+      client.query({
+        query: `
+          SELECT
+            toDate(viewed_at) AS date,
+            toUInt64(count()) AS impressions,
+            toUInt64(uniq(session_id)) AS unique_viewers
+          FROM resource_views
+          WHERE (${timePred})
+            AND (${resourceWhere})
+          GROUP BY date
+          ORDER BY date
+        `,
+        query_params: baseParams,
+        format: "JSONEachRow",
+      }),
+      client.query({
+        query: `
+          SELECT
+            toUInt64(count()) AS impressions,
+            toUInt64(uniq(session_id)) AS unique_viewers
+          FROM resource_views
+          WHERE (${timePred})
+            AND (${resourceWhere})
+        `,
+        query_params: baseParams,
+        format: "JSONEachRow",
+      }),
+    ]);
+
+    const seriesRows = (await seriesResult.json()) as Array<{
+      date: string;
+      impressions: string | number;
+      unique_viewers: string | number;
+    }>;
+
+    const totalsRows = (await totalsResult.json()) as Array<{
+      impressions: string | number;
+      unique_viewers: string | number;
+    }>;
+
+    const totalsRow = totalsRows[0];
+
+    return {
+      success: true,
+      data: {
+        series: seriesRows.map((r) => ({
+          date: String(r.date),
+          impressions: Number(r.impressions),
+          unique_viewers: Number(r.unique_viewers),
+        })),
+        totals: {
+          impressions: Number(totalsRow?.impressions ?? 0),
+          unique_viewers: Number(totalsRow?.unique_viewers ?? 0),
+        },
+        reactions,
+        bookmarks,
+        clickhouseConfigured: true,
+        publishedArticleCount: articleIds.length,
+        publicGistCount: gistIds.length,
+      },
+    };
+  } catch (error) {
+    return handleActionException(error);
+  }
+}

--- a/src/backend/services/inputs/analytics.input.ts
+++ b/src/backend/services/inputs/analytics.input.ts
@@ -1,0 +1,73 @@
+import { z } from "zod/v4";
+
+const ymd = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Expected YYYY-MM-DD");
+
+const analyticsRangeFields = {
+  range_days: z.coerce.number().int().min(1).max(365).optional(),
+  start_date: ymd.optional(),
+  end_date: ymd.optional(),
+};
+
+function refineAnalyticsRange(
+  v: {
+    range_days?: number;
+    start_date?: string;
+    end_date?: string;
+  },
+  ctx: z.RefinementCtx,
+) {
+  const hasCustom = v.start_date != null && v.end_date != null;
+  const hasPartial =
+    (v.start_date != null && v.end_date == null) ||
+    (v.start_date == null && v.end_date != null);
+  if (hasPartial) {
+    ctx.addIssue({
+      code: "custom",
+      message: "Provide both start_date and end_date for a custom range",
+      path: ["start_date"],
+    });
+  }
+  if (hasCustom && v.range_days != null) {
+    ctx.addIssue({
+      code: "custom",
+      message: "Use either range_days or start_date/end_date, not both",
+      path: ["range_days"],
+    });
+  }
+  if (hasCustom && v.start_date! > v.end_date!) {
+    ctx.addIssue({
+      code: "custom",
+      message: "start_date must be on or before end_date",
+      path: ["start_date"],
+    });
+  }
+}
+
+export const TRACKED_RESOURCE_TYPES = ["ARTICLE", "GIST"] as const;
+export type TrackedResourceType = (typeof TRACKED_RESOURCE_TYPES)[number];
+
+/** Stored in ClickHouse `session_type`; `session_id` is anon token or user UUID string. */
+export const ANALYTICS_SESSION_TYPES = ["ANON", "AUTHENTICATED"] as const;
+export type AnalyticsSessionType = (typeof ANALYTICS_SESSION_TYPES)[number];
+
+export const AnalyticsInput = {
+  recordViewBody: z.object({
+    resource_type: z.enum(TRACKED_RESOURCE_TYPES),
+    resource_id: z.string().uuid(),
+    session_id: z.string().min(8).max(128),
+  }),
+
+  getResourceAnalyticsInput: z
+    .object({
+      resource_type: z.enum(TRACKED_RESOURCE_TYPES),
+      resource_id: z.string().uuid(),
+      ...analyticsRangeFields,
+    })
+    .superRefine(refineAnalyticsRange),
+
+  getDashboardAnalyticsOverviewInput: z
+    .object({
+      ...analyticsRangeFields,
+    })
+    .superRefine(refineAnalyticsRange),
+};

--- a/src/components/Editor/ArticleEditor.tsx
+++ b/src/components/Editor/ArticleEditor.tsx
@@ -16,7 +16,7 @@ import { useToggle } from "@/hooks/use-toggle";
 import { actionPromisify, formattedTime } from "@/lib/utils";
 import { useMutation } from "@tanstack/react-query";
 import clsx from "clsx";
-import { TrashIcon } from "lucide-react";
+import { LineChartIcon, TrashIcon } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
@@ -235,7 +235,16 @@ const ArticleEditor: React.FC<ArticleEditorProps> = ({ article, uuid }) => {
           </div>
 
           {uuid && (
-            <div className="flex gap-2">
+            <div className="flex gap-2 items-center">
+              {article?.published_at ? (
+                <Link
+                  href={`/dashboard/analytics/article/${uuid}`}
+                  className="hidden md:inline-flex items-center gap-1.5 px-3 py-1 text-sm font-semibold text-muted-foreground transition-colors rounded-sm hover:bg-muted hover:text-foreground"
+                >
+                  <LineChartIcon className="size-4" />
+                  {_t("Analytics")}
+                </Link>
+              ) : null}
               <button
                 onClick={toggleEditorMode}
                 className="px-4 py-1 hidden md:block font-semibold transition-colors duration-200 rounded-sm hover:bg-muted"

--- a/src/components/Gist/GistEditor.tsx
+++ b/src/components/Gist/GistEditor.tsx
@@ -20,6 +20,7 @@ import {
   LockClosedIcon,
   ArrowLeftIcon,
 } from "@radix-ui/react-icons";
+import { LineChartIcon } from "lucide-react";
 import Link from "next/link";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
@@ -285,13 +286,24 @@ export default function GistEditor({ gist, onSuccess }: GistEditorProps) {
   return (
     <div className="max-w-4xl mx-auto px-4 py-8 space-y-6">
       {gist && (
-        <Link
-          href={`/gists/${gist.id}`}
-          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
-        >
-          <ArrowLeftIcon className="w-3.5 h-3.5" />
-          Back to gist
-        </Link>
+        <div className="flex flex-wrap items-center gap-4">
+          <Link
+            href={`/gists/${gist.id}`}
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ArrowLeftIcon className="w-3.5 h-3.5" />
+            Back to gist
+          </Link>
+          {isPublic ? (
+            <Link
+              href={`/dashboard/analytics/gist/${gist.id}`}
+              className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <LineChartIcon className="w-3.5 h-3.5" />
+              Analytics
+            </Link>
+          ) : null}
+        </div>
       )}
 
       {/* Meta section */}

--- a/src/components/Gist/GistViewer.tsx
+++ b/src/components/Gist/GistViewer.tsx
@@ -24,6 +24,7 @@ import {
   CommentSection,
   CommentSectionProvider,
 } from "@/components/comment-section";
+import { ResourceViewTracker } from "@/components/analytics/ResourceViewTracker";
 import ResourceReaction from "@/components/ResourceReaction";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
@@ -154,6 +155,9 @@ export default function GistViewer({
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-8 space-y-6">
+      {gist.is_public ? (
+        <ResourceViewTracker resourceType="GIST" resourceId={gist.id} />
+      ) : null}
       {/* Header */}
       <div className="space-y-3">
         <div className="flex items-start justify-between gap-4">

--- a/src/components/analytics/AnalyticsRangeControls.tsx
+++ b/src/components/analytics/AnalyticsRangeControls.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import * as React from "react";
+import { useTranslation } from "@/i18n/use-translation";
+import { Button } from "@/components/ui/button";
+
+const PRESET_DAYS = [7, 30, 90] as const;
+export type PresetDays = (typeof PRESET_DAYS)[number];
+
+export type AnalyticsTimeRange =
+  | { kind: "preset"; days: PresetDays }
+  | { kind: "custom"; start_date: string; end_date: string };
+
+function toYmdUTC(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function defaultCustomRange(): { start_date: string; end_date: string } {
+  const end = new Date();
+  const start = new Date();
+  start.setUTCDate(start.getUTCDate() - 29);
+  return { start_date: toYmdUTC(start), end_date: toYmdUTC(end) };
+}
+
+type AnalyticsRangeControlsProps = {
+  value: AnalyticsTimeRange;
+  onChange: (next: AnalyticsTimeRange) => void;
+};
+
+export function AnalyticsRangeControls({ value, onChange }: AnalyticsRangeControlsProps) {
+  const { _t } = useTranslation();
+  const [draftStart, setDraftStart] = React.useState(
+    value.kind === "custom" ? value.start_date : defaultCustomRange().start_date,
+  );
+  const [draftEnd, setDraftEnd] = React.useState(
+    value.kind === "custom" ? value.end_date : defaultCustomRange().end_date,
+  );
+
+  React.useEffect(() => {
+    if (value.kind === "custom") {
+      setDraftStart(value.start_date);
+      setDraftEnd(value.end_date);
+    }
+  }, [value]);
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
+      <div className="flex flex-wrap gap-2">
+        {PRESET_DAYS.map((d) => (
+          <button
+            key={d}
+            type="button"
+            onClick={() => onChange({ kind: "preset", days: d })}
+            className={
+              value.kind === "preset" && value.days === d
+                ? "rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground"
+                : "rounded-md border border-border bg-background px-3 py-1.5 text-sm text-muted-foreground hover:bg-muted"
+            }
+          >
+            {d}d
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={() => {
+            const r = defaultCustomRange();
+            onChange({ kind: "custom", ...r });
+          }}
+          className={
+            value.kind === "custom"
+              ? "rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground"
+              : "rounded-md border border-border bg-background px-3 py-1.5 text-sm text-muted-foreground hover:bg-muted"
+          }
+        >
+          {_t("Custom")}
+        </button>
+      </div>
+
+      {value.kind === "custom" ? (
+        <div className="flex flex-wrap items-end gap-2">
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            <span>{_t("From")}</span>
+            <input
+              type="date"
+              value={draftStart}
+              onChange={(e) => setDraftStart(e.target.value)}
+              className="h-9 rounded-md border border-input bg-background px-2 text-sm text-foreground"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            <span>{_t("To")}</span>
+            <input
+              type="date"
+              value={draftEnd}
+              onChange={(e) => setDraftEnd(e.target.value)}
+              className="h-9 rounded-md border border-input bg-background px-2 text-sm text-foreground"
+            />
+          </label>
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            className="h-9"
+            onClick={() => {
+              if (!draftStart || !draftEnd || draftStart > draftEnd) {
+                return;
+              }
+              onChange({
+                kind: "custom",
+                start_date: draftStart,
+                end_date: draftEnd,
+              });
+            }}
+          >
+            {_t("Apply")}
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function analyticsTimeRangeToQueryPayload(
+  range: AnalyticsTimeRange,
+): { range_days: number; start_date?: undefined; end_date?: undefined } | { start_date: string; end_date: string; range_days?: undefined } {
+  if (range.kind === "preset") {
+    return { range_days: range.days };
+  }
+  return { start_date: range.start_date, end_date: range.end_date };
+}

--- a/src/components/analytics/ResourceAnalyticsDashboard.tsx
+++ b/src/components/analytics/ResourceAnalyticsDashboard.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import * as React from "react";
+import { getResourceAnalytics } from "@/backend/services/analytics.actions";
+import type { TrackedResourceType } from "@/backend/services/inputs/analytics.input";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import { useTranslation } from "@/i18n/use-translation";
+import { actionPromisify } from "@/lib/utils";
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import {
+  AnalyticsRangeControls,
+  analyticsTimeRangeToQueryPayload,
+  type AnalyticsTimeRange,
+} from "@/components/analytics/AnalyticsRangeControls";
+import { Line, LineChart, CartesianGrid, XAxis } from "recharts";
+
+const chartConfig = {
+  unique_viewers: {
+    label: "Unique viewers",
+    color: "var(--chart-1)",
+  },
+  impressions: {
+    label: "Impressions",
+    color: "var(--chart-2)",
+  },
+} satisfies ChartConfig;
+
+type ResourceAnalyticsDashboardProps = {
+  resourceType: TrackedResourceType;
+  resourceId: string;
+  /** e.g. article or gist title (shown above the chart). */
+  resourceTitle?: string | null;
+  /** Link to the public reader page for this resource. */
+  publicReaderHref?: string | null;
+};
+
+export function ResourceAnalyticsDashboard({
+  resourceType,
+  resourceId,
+  resourceTitle,
+  publicReaderHref,
+}: ResourceAnalyticsDashboardProps) {
+  const { _t } = useTranslation();
+  const [timeRange, setTimeRange] = React.useState<AnalyticsTimeRange>({
+    kind: "preset",
+    days: 30,
+  });
+
+  const rangePayload = analyticsTimeRangeToQueryPayload(timeRange);
+
+  const query = useQuery({
+    queryKey: ["resource-analytics", resourceType, resourceId, rangePayload],
+    queryFn: () =>
+      actionPromisify(
+        getResourceAnalytics({
+          resource_type: resourceType,
+          resource_id: resourceId,
+          ...rangePayload,
+        }),
+      ),
+  });
+
+  if (query.isPending) {
+    return (
+      <div className="space-y-4">
+        <div className="h-24 animate-pulse rounded-lg bg-muted" />
+        <div className="h-[280px] animate-pulse rounded-lg bg-muted" />
+      </div>
+    );
+  }
+
+  if (query.isError) {
+    return (
+      <p className="text-sm text-destructive">
+        {query.error instanceof Error ? query.error.message : String(query.error)}
+      </p>
+    );
+  }
+
+  const data = query.data;
+  const chartData = data.series.map((row) => ({
+    ...row,
+    dateLabel: row.date.slice(5),
+  }));
+
+  return (
+    <div className="space-y-6">
+      {resourceTitle ? (
+        <div className="space-y-1">
+          <p className="text-lg font-semibold leading-snug text-foreground">
+            {resourceTitle}
+          </p>
+          {publicReaderHref ? (
+            <Link
+              href={publicReaderHref}
+              className="text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+            >
+              {_t("View public page")}
+            </Link>
+          ) : null}
+        </div>
+      ) : null}
+      {!data.clickhouseConfigured ? (
+        <p className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-950 dark:text-amber-100">
+          {_t(
+            "View analytics are not configured (ClickHouse env missing). Reaction and bookmark counts still reflect your content.",
+          )}
+        </p>
+      ) : null}
+
+      <AnalyticsRangeControls value={timeRange} onChange={setTimeRange} />
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <Card className="rounded-lg">
+          <CardHeader className="pb-2">
+            <CardDescription>{_t("Unique viewers")}</CardDescription>
+            <CardTitle className="text-2xl tabular-nums">
+              {data.totals.unique_viewers}
+            </CardTitle>
+          </CardHeader>
+        </Card>
+        <Card className="rounded-lg">
+          <CardHeader className="pb-2">
+            <CardDescription>{_t("Impressions")}</CardDescription>
+            <CardTitle className="text-2xl tabular-nums">
+              {data.totals.impressions}
+            </CardTitle>
+          </CardHeader>
+        </Card>
+        <Card className="rounded-lg">
+          <CardHeader className="pb-2">
+            <CardDescription>{_t("Reactions")}</CardDescription>
+            <CardTitle className="text-2xl tabular-nums">{data.reactions}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card className="rounded-lg">
+          <CardHeader className="pb-2">
+            <CardDescription>{_t("Bookmarks")}</CardDescription>
+            <CardTitle className="text-2xl tabular-nums">{data.bookmarks}</CardTitle>
+          </CardHeader>
+        </Card>
+      </div>
+
+      <Card className="rounded-lg">
+        <CardHeader>
+          <CardTitle>{_t("Views over time")}</CardTitle>
+          <CardDescription>
+            {_t("Unique viewers and impressions per day")}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {chartData.length === 0 ? (
+            <p className="text-sm text-muted-foreground">{_t("No view data in this range yet.")}</p>
+          ) : (
+            <ChartContainer config={chartConfig} className="max-h-[320px] w-full">
+              <LineChart
+                accessibilityLayer
+                data={chartData}
+                margin={{ left: 8, right: 8, top: 8, bottom: 0 }}
+              >
+                <CartesianGrid vertical={false} />
+                <XAxis
+                  dataKey="dateLabel"
+                  tickLine={false}
+                  axisLine={false}
+                  tickMargin={8}
+                />
+                <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
+                <Line
+                  type="monotone"
+                  dataKey="unique_viewers"
+                  stroke="var(--color-unique_viewers)"
+                  strokeWidth={2}
+                  dot={false}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="impressions"
+                  stroke="var(--color-impressions)"
+                  strokeWidth={2}
+                  dot={false}
+                />
+              </LineChart>
+            </ChartContainer>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/analytics/ResourceViewTracker.tsx
+++ b/src/components/analytics/ResourceViewTracker.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import type { TrackedResourceType } from "@/backend/services/inputs/analytics.input";
+import { useEffect, useRef } from "react";
+
+const STORAGE_KEY = "td_analytics_sid";
+
+function getOrCreateSessionId(): string {
+  try {
+    const existing = localStorage.getItem(STORAGE_KEY);
+    if (existing && existing.length >= 8) {
+      return existing;
+    }
+    const id = crypto.randomUUID();
+    localStorage.setItem(STORAGE_KEY, id);
+    return id;
+  } catch {
+    return crypto.randomUUID();
+  }
+}
+
+type ResourceViewTrackerProps = {
+  resourceType: TrackedResourceType;
+  resourceId: string;
+  enabled?: boolean;
+};
+
+/**
+ * Fire-and-forget view event on mount (each full page load / refresh appends one row).
+ */
+export function ResourceViewTracker({
+  resourceType,
+  resourceId,
+  enabled = true,
+}: ResourceViewTrackerProps) {
+  const sent = useRef(false);
+
+  useEffect(() => {
+    if (!enabled || sent.current) {
+      return;
+    }
+    sent.current = true;
+
+    const sessionId = getOrCreateSessionId();
+    const body = JSON.stringify({
+      resource_type: resourceType,
+      resource_id: resourceId,
+      session_id: sessionId,
+    });
+
+    try {
+      void fetch("/api/analytics/view", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+        keepalive: true,
+      });
+    } catch {
+      // ignore
+    }
+  }, [enabled, resourceId, resourceType]);
+
+  return null;
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -29,6 +29,32 @@ export const env = createEnv({
     PUSHER_APP_ID: z.string().min(1),
     PUSHER_APP_KEY: z.string().min(1),
     PUSHER_APP_SECRET: z.string().min(1),
+
+    // ClickHouse (resource analytics) — all optional; when unset, ingest/query no-op
+    CLICKHOUSE_HOST: z
+      .string()
+      .optional()
+      .transform((v) => (v === "" ? undefined : v)),
+    CLICKHOUSE_PORT: z
+      .string()
+      .optional()
+      .transform((v) => (v === "" ? undefined : v)),
+    CLICKHOUSE_USERNAME: z
+      .string()
+      .optional()
+      .transform((v) => (v === "" ? undefined : v)),
+    CLICKHOUSE_PASSWORD: z
+      .string()
+      .optional()
+      .transform((v) => (v === "" ? undefined : v)),
+    CLICKHOUSE_DATABASE: z
+      .string()
+      .optional()
+      .transform((v) => (v === "" ? undefined : v)),
+    CLICKHOUSE_SECURE: z.preprocess(
+      (v) => (v === "" || v === undefined ? undefined : v),
+      z.enum(["true", "false"]).optional(),
+    ),
   },
   client: {
     NEXT_PUBLIC_MEILISEARCH_API_HOST: z.url(),
@@ -68,6 +94,13 @@ export const env = createEnv({
 
     NEXT_PUBLIC_PUSHER_APP_KEY: process.env.NEXT_PUBLIC_PUSHER_APP_KEY,
     NEXT_PUBLIC_PUSHER_WS_HOST: process.env.NEXT_PUBLIC_PUSHER_WS_HOST,
+
+    CLICKHOUSE_HOST: process.env.CLICKHOUSE_HOST,
+    CLICKHOUSE_PORT: process.env.CLICKHOUSE_PORT,
+    CLICKHOUSE_USERNAME: process.env.CLICKHOUSE_USERNAME,
+    CLICKHOUSE_PASSWORD: process.env.CLICKHOUSE_PASSWORD,
+    CLICKHOUSE_DATABASE: process.env.CLICKHOUSE_DATABASE,
+    CLICKHOUSE_SECURE: process.env.CLICKHOUSE_SECURE as "true" | "false" | undefined,
   },
   onValidationError(issues: readonly StandardSchemaV1.Issue[]) {
     console.error("❌ Invalid environment variables:", issues);


### PR DESCRIPTION
## Overview

Ships **writer-facing analytics** aligned with the [resource analytics plan](docs/resource-analytics-plan.md) and the intent of #114: **reach** (views/impressions, deduped by session) plus **engagement** from Postgres (reactions, bookmarks).

- **Aggregate dashboard** (`/dashboard`): "Reach & views" — totals and a time-series across **all published articles + public gists** you own (bounded list sizes for CH queries).
- **Per-resource** (`/dashboard/analytics/article/:id`, `/dashboard/analytics/gist/:id`): same metrics for one article or gist, with title, back link, and "View public page" when applicable.
- **Ingestion**: `POST /api/analytics/view` appends rows to ClickHouse; **no-op 204** if ClickHouse env is missing so local dev stays usable.

## How it was built

### Data store (ClickHouse)

- Table **`resource_views`** (`migrations/clickhouse-schema.sql`): `resource_type`, `resource_id`, `session_type` (`ANON` | `AUTHENTICATED`), `session_id`, optional `referrer` / `country_code`, `viewed_at`.
- **Session model**: one column `session_id` — for logged-in users the API stores **`AUTHENTICATED` + user id**; otherwise **`ANON` + client token** from `localStorage`. Enables `uniq(session_id)` for "unique viewers" while still counting **impressions** with `count()`.
- Queries use either **preset windows** (`now() - INTERVAL n DAY`) or **custom UTC calendar ranges** via `parseDateTimeBestEffort` on inclusive start / exclusive end.

### App code

- **`@clickhouse/client`** singleton: `src/backend/persistence/clickhouse.client.ts` (optional env; disabled when vars unset).
- **Server actions**: `getResourceAnalytics`, `getDashboardAnalyticsOverview` in `analytics.actions.ts` — ownership checks (article author / gist owner), CH aggregates, Postgres counts.
- **API route**: `src/app/api/analytics/view/route.ts`.
- **Client tracker**: `ResourceViewTracker` on **published** article pages and **public** gist views.
- **UI**: `ResourceAnalyticsDashboard`, `DashboardAnalyticsOverview`, shared **`AnalyticsRangeControls`** (7d / 30d / 90d / **Custom** + Apply).
- **Env** (`src/env.ts`): `CLICKHOUSE_HOST`, `CLICKHOUSE_PORT`, `CLICKHOUSE_USERNAME`, `CLICKHOUSE_PASSWORD`, `CLICKHOUSE_DATABASE`, `CLICKHOUSE_SECURE` (all optional).

### Navigation / discoverability

- Dashboard **Reach** sidebar link → `#dashboard-analytics`.
- Article list: **Article analytics** chip + actions menu for published posts.
- Article editor: **Analytics** when published.

## Notes

- Reactions / bookmarks in the UI are **lifetime** totals for that resource (or all tracked resources on the overview), not filtered by the selected date range — only view metrics are range-scoped.
- Older DBs that had `viewer_id` can migrate with `migrations/clickhouse-migrate-session-type-*.sql` (one statement per HTTP request).